### PR TITLE
fix: 动态获取API基础URL以替代硬编码的localhost

### DIFF
--- a/web/gpu/script.js
+++ b/web/gpu/script.js
@@ -1,5 +1,5 @@
-// API URL
-const API_BASE_URL = 'http://localhost:5000/api';
+// API URL - 动态获取当前host
+const API_BASE_URL = `http://${window.location.hostname}:5000/api`;
 
 // 用于存储数据的变量
 let gpuData = [];

--- a/web/logs/logs.js
+++ b/web/logs/logs.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = `http://${window.location.hostname}:5000/api`;
 
 // 全局变量
 let logFiles = [];

--- a/web/settings/settings.js
+++ b/web/settings/settings.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = `http://${window.location.hostname}:5000/api`;
 
 // 全局变量
 let currentSettings = {}; // 存储当前设置
@@ -367,4 +367,4 @@ function getSectionName(section) {
     };
     
     return names[section] || '设置';
-} 
+}

--- a/web/tasks/tasks.js
+++ b/web/tasks/tasks.js
@@ -1,5 +1,5 @@
 // API URL
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = `http://${window.location.hostname}:5000/api`;
 
 // 全局变量
 let tasks = [];


### PR DESCRIPTION
解决了 #2 的问题。

该问题是由于写死域名导致的，目前采取方案是使用web页面的域名来进行寻址，从而避免固定地址的问题。

复现该问题的主要场景是: 
主机ip是A，用户所在电脑ip是B，而用户使用A:8000进行web端访问的时候，web端会去寻找B:5000。

## Summary by Sourcery

Bug Fixes:
- Replace hardcoded 'http://localhost:5000/api' with `http://${window.location.hostname}:5000/api` in gpu, settings, logs, and tasks modules to fix incorrect host resolution