### PR TITLE
Feat/autoinit

### DIFF
--- a/flowline/api/interface.py
+++ b/flowline/api/interface.py
@@ -16,7 +16,7 @@ class CommandLineInterface(cmd.Cmd):
         try:
             with open(filename) as f:
                 lines = f.read().splitlines()
-            self.cmdqueue.extend(reversed(lines))
+            self.cmdqueue.extend(lines)
         except FileNotFoundError:
             print("No init file found")
         except OSError | PermissionError as e:

--- a/flowline/api/interface.py
+++ b/flowline/api/interface.py
@@ -12,6 +12,16 @@ class CommandLineInterface(cmd.Cmd):
         super().__init__()
         self.program_manager = program_manager
         
+    def do_load(self, filename):
+        try:
+            with open(filename) as f:
+                lines = f.read().splitlines()
+            self.cmdqueue.extend(reversed(lines))
+        except FileNotFoundError:
+            print("No init file found")
+        except OSError | PermissionError as e:
+            print(f"OS error: {e}")
+        
     def do_run(self, arg):
         """switch running status: run"""
         is_run = self.program_manager.switch_run()
@@ -129,18 +139,19 @@ class CommandLineInterface(cmd.Cmd):
             print(f"{v['task_id']:<8} {v['name']:<12} {v['run_num']:<8} {v['dict']:<20}")
         print("-" * 100)
 
-def run_cli(func, task_dir=None, user_cmp=None):
+def run_cli(func, task_dir=None, user_cmp=None, init_file='./.flinit'):
     """run the command line interface"""
     program = ProgramManager(func, task_dir, user_cmp)
     cli = CommandLineInterface(program)
     try:
+        cli.do_load(init_file)
         cli.cmdloop()
     except KeyboardInterrupt:
         print("\nreceived interrupt signal, exiting...")
         sys.exit(0)
 
 if __name__ == "__main__":
-    pass
+    run_cli(None)
 
 """
     python -m flowline.interface

--- a/flowline/core/gpu.py
+++ b/flowline/core/gpu.py
@@ -46,6 +46,8 @@ class GPU:
         self.monitor_interval = 5
         self.monitor_thread = self._run_monitor()
         
+        self.flash()
+        
     def flash(self):
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(self.gpu_id)


### PR DESCRIPTION
添加了类似于gdb和pdb那样自动执行用户在文件中保存的初始化命令的功能

## Summary by Sourcery

Add support for automatically loading and executing initialization commands on CLI startup and trigger an immediate GPU status refresh when creating a GPU manager instance.

New Features:
- Load and execute initialization commands from a configurable init file when starting the CLI.

Enhancements:
- Automatically perform an initial GPU status flash when initializing the GPU manager.
- Provide a default CLI entrypoint that runs the command-line interface when the module is executed as a script.